### PR TITLE
Makes layout wide to support width in percentage

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -48,7 +48,8 @@ st.set_page_config(
         'Get Help': 'https://github.com/lfoppiano/pdf-struct',
         'Report a bug': "https://github.com/lfoppiano/pdf-struct/issues",
         'About': "View the structures extracted by Grobid."
-    }
+    },
+    layout='wide'
 )
 
 with st.sidebar:
@@ -192,7 +193,6 @@ if uploaded_file:
 
         pdf_viewer(
             input=st.session_state['binary'],
-            width=700,
             annotations=annotations,
             pages_vertical_spacing=pages_vertical_spacing,
             annotation_outline_size=annotation_thickness,


### PR DESCRIPTION
relating with this issue https://github.com/lfoppiano/streamlit-pdf-viewer/issues/30 and this PR  https://github.com/lfoppiano/streamlit-pdf-viewer/pull/39
The default layout width is around 730px. Specifying 100% doesn't work as expected and makes it appear buggy due to this size limitation.